### PR TITLE
Fix youtube url validation

### DIFF
--- a/app/Http/Controllers/VideoController.php
+++ b/app/Http/Controllers/VideoController.php
@@ -119,7 +119,7 @@ class VideoController extends Controller
         $video = $this->assistUpdateVideo($request, $id);
 
         if ($video === false) {
-            return redirect('/dashboard/video/edit'.$id)->with(
+            return redirect('/dashboard/video/edit/'.$id)->with(
                 'status',
                 'Invalid url'
             );
@@ -129,7 +129,7 @@ class VideoController extends Controller
             return redirect('/dashboard/video/view');
         }
 
-        return redirect('/dashboard/video/edit'.$id)->with(
+        return redirect('/dashboard/video/edit/'.$id)->with(
             'status',
             'Oops! Something went wrong!'
         );
@@ -195,7 +195,7 @@ class VideoController extends Controller
             return false;
         }
 
-        return strlen($my_array_of_vars['v']) == 11 ? $my_array_of_vars['v'] : false ;
+        return strlen($my_array_of_vars['v']) == 11 ? $my_array_of_vars['v'] : false;
     }
 
     /**

--- a/app/Http/Controllers/VideoController.php
+++ b/app/Http/Controllers/VideoController.php
@@ -195,7 +195,7 @@ class VideoController extends Controller
             return false;
         }
 
-        return $my_array_of_vars['v'];
+        return strlen($my_array_of_vars['v']) == 11 ? $my_array_of_vars['v'] : false ;
     }
 
     /**

--- a/app/Http/Requests/VideoRequest.php
+++ b/app/Http/Requests/VideoRequest.php
@@ -25,7 +25,7 @@ class VideoRequest extends Request
            'title'        => 'required|max:50|unique:videos',
            'description'  => 'required|max:256',
            'category'     => 'required|max:5',
-           'url'          => 'required|min:10,url,',
+           'url'          => 'required|min:10|unique:videos',
         ];
     }
 }

--- a/app/Http/Requests/VideoRequest.php
+++ b/app/Http/Requests/VideoRequest.php
@@ -25,7 +25,7 @@ class VideoRequest extends Request
            'title'        => 'required|max:50|unique:videos',
            'description'  => 'required|max:256',
            'category'     => 'required|max:5',
-           'url'          => 'required|min:10|unique:videos',
+           'url'          => 'required|min:10,url,',
         ];
     }
 }

--- a/tests/VideoTest.php
+++ b/tests/VideoTest.php
@@ -232,6 +232,7 @@ class VideoTest extends TestCase
           ->select($category->id, 'category')
           ->type('I have made you too small in my heart', 'title')
           ->type('It is the language of the Html', 'description')
+          ->type('https://www.youtube.com/watch?v=hKUwxXgz2RM', 'url')
           ->press('Update')
           ->seePageIs('/dashboard/video/view')
           ->see('I have made you too small in my heart');


### PR DESCRIPTION
The initial validation only cater for the url format but does not consider the 11 character representing the unique id of the video
